### PR TITLE
메시지 전송 / 조회 / 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.1'
+	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.2'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	implementation 'org.postgresql:postgresql:42.6.0'
 }

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -1,4 +1,28 @@
 package com.gucci.message_service.controller;
 
+import com.gucci.common.response.ApiResponse;
+import com.gucci.common.response.SuccessCode;
+import com.gucci.message_service.dto.MessageResponseDTO;
+import com.gucci.message_service.dto.MessageSendRequestDTO;
+import com.gucci.message_service.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/message-service")
 public class MessageController {
+
+    private final MessageService messageService;
+
+    // 메시지 전송
+    @PostMapping("/send")
+    public ApiResponse<Void> send(@RequestHeader("X-User-Id") Long senderId,
+                                  @RequestBody MessageSendRequestDTO message) {
+        messageService.send(senderId, message);
+        return ApiResponse.success();
+    }
+
 }

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -49,6 +49,13 @@ public class MessageController {
         return ApiResponse.success();
     }
 
+    // 방 나가기 (특정 유저와의 메시지 전체 삭제(논리적))
+    @PostMapping("/room/exit/{targetUserId}")
+    public ApiResponse<Void> exitRoomWithTarget(@RequestHeader("X-User-Id") Long userId,
+                                                @PathVariable Long targetUserId) {
+        messageService.exitRoomWithTarget(userId, targetUserId);
+        return ApiResponse.success();
+    }
 
 
 }

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -1,0 +1,4 @@
+package com.gucci.message_service.controller;
+
+public class MessageController {
+}

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -33,4 +33,13 @@ public class MessageController {
         return ApiResponse.success(SuccessCode.DATA_FETCHED, rooms);
     }
 
+    // 특정 유저와의 전체 메시지 조회
+    @GetMapping("/with/{targetUserId}")
+    public ApiResponse<List<MessageResponseDTO>> getMessagesWithTarget(@RequestHeader("X-User-Id") Long userId,
+                                                             @PathVariable Long targetUserId) {
+        List<MessageResponseDTO> messages = messageService.getMessagesWithTarget(userId, targetUserId);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, messages);
+    }
+
+
 }

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -3,6 +3,7 @@ package com.gucci.message_service.controller;
 import com.gucci.common.response.ApiResponse;
 import com.gucci.common.response.SuccessCode;
 import com.gucci.message_service.dto.MessageResponseDTO;
+import com.gucci.message_service.dto.MessageRoomResponseDTO;
 import com.gucci.message_service.dto.MessageSendRequestDTO;
 import com.gucci.message_service.service.MessageService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,13 @@ public class MessageController {
                                   @RequestBody MessageSendRequestDTO message) {
         messageService.send(senderId, message);
         return ApiResponse.success();
+    }
+
+    // 방 리스트 조회
+    @GetMapping("/rooms")
+    public ApiResponse<List<MessageRoomResponseDTO>> getRooms(@RequestHeader("X-User-Id") Long userId) {
+        List<MessageRoomResponseDTO> rooms = messageService.getRooms(userId);
+        return ApiResponse.success(SuccessCode.DATA_FETCHED, rooms);
     }
 
 }

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -41,5 +41,14 @@ public class MessageController {
         return ApiResponse.success(SuccessCode.DATA_FETCHED, messages);
     }
 
+    // 특정 메시지 삭제
+    @DeleteMapping("/{messageId}")
+    public ApiResponse<Void> deleteMessage(@RequestHeader("X-User-Id") Long userId,
+                                           @PathVariable Long messageId) {
+        messageService.deleteMessage(userId, messageId);
+        return ApiResponse.success();
+    }
+
+
 
 }

--- a/src/main/java/com/gucci/message_service/domain/Message.java
+++ b/src/main/java/com/gucci/message_service/domain/Message.java
@@ -46,6 +46,14 @@ public class Message {
         }
     }
 
+    public void markAsDeleteByReceiver() {
+        this.deletedByReceiver = true;
+    }
+
+    public void markAsDeleteBySender() {
+        this.deletedByReceiver = true;
+    }
+
     public void markAsRead() {
         this.isRead = true;
     }

--- a/src/main/java/com/gucci/message_service/domain/Message.java
+++ b/src/main/java/com/gucci/message_service/domain/Message.java
@@ -51,7 +51,7 @@ public class Message {
     }
 
     public void markAsDeleteBySender() {
-        this.deletedByReceiver = true;
+        this.deletedBySender = true;
     }
 
     public void markAsRead() {

--- a/src/main/java/com/gucci/message_service/domain/Message.java
+++ b/src/main/java/com/gucci/message_service/domain/Message.java
@@ -1,0 +1,53 @@
+package com.gucci.message_service.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "messages")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Message {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long receiverId;
+
+    @Column(nullable = false)
+    private Long senderId;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean isRead;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean deletedByReceiver;
+
+    @Column(columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean deletedBySender;
+
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+}

--- a/src/main/java/com/gucci/message_service/dto/MessageResponseDTO.java
+++ b/src/main/java/com/gucci/message_service/dto/MessageResponseDTO.java
@@ -1,0 +1,19 @@
+package com.gucci.message_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MessageResponseDTO {
+    private Long id;
+    private Long senderId;
+    private Long receiverId;
+    private String content;
+    private boolean isRead;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/gucci/message_service/dto/MessageRoomResponseDTO.java
+++ b/src/main/java/com/gucci/message_service/dto/MessageRoomResponseDTO.java
@@ -1,0 +1,17 @@
+package com.gucci.message_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MessageRoomResponseDTO {
+    private Long targetUserId; // 상대방 ID
+    private String targetNickname; // 상대방 이름
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+}

--- a/src/main/java/com/gucci/message_service/dto/MessageSendRequestDTO.java
+++ b/src/main/java/com/gucci/message_service/dto/MessageSendRequestDTO.java
@@ -1,0 +1,11 @@
+package com.gucci.message_service.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MessageSendRequestDTO {
+    private Long receiverId;
+    private String content;
+}

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -1,0 +1,8 @@
+package com.gucci.message_service.repository;
+
+import com.gucci.message_service.domain.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+}

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -2,7 +2,23 @@ package com.gucci.message_service.repository;
 
 import com.gucci.message_service.domain.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
+    List<Message> findByReceiverIdAndOrderByCreatedAtDesc(Long receiverId);
+
+    List<Message> findByReceiverIdOrSenderId(Long receiverId, Long senderId);
+
+    // 삭제되지 않은 메시지 전부 최신순으로 반환
+    @Query("""
+    SELECT m FROM Message m
+    WHERE (m.receiverId = :userId OR m.senderId = :userId)
+    AND (m.deletedByReceiver = false OR m.deletedBySender = false)
+    ORDER BY m.createdAt DESC
+    """)
+    List<Message> findAllRelatedMessages(@Param("userId") Long userId);
 }

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -8,17 +8,23 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
-
-    List<Message> findByReceiverIdAndOrderByCreatedAtDesc(Long receiverId);
-
-    List<Message> findByReceiverIdOrSenderId(Long receiverId, Long senderId);
-
     // 삭제되지 않은 메시지 전부 최신순으로 반환
     @Query("""
-    SELECT m FROM Message m
-    WHERE (m.receiverId = :userId OR m.senderId = :userId)
-    AND (m.deletedByReceiver = false OR m.deletedBySender = false)
-    ORDER BY m.createdAt DESC
-    """)
+            SELECT m FROM Message m
+            WHERE (m.receiverId = :userId OR m.senderId = :userId)
+            AND (m.deletedByReceiver = false OR m.deletedBySender = false)
+            ORDER BY m.createdAt DESC
+            """)
     List<Message> findAllRelatedMessages(@Param("userId") Long userId);
+
+
+    // 특정 상대와의 채팅 내역 최신순으로 반환
+    @Query("""
+            SELECT m FROM Message m
+            WHERE (m.receiverId = :userId AND m.senderId = :targetUserId AND m.deletedByReceiver = false)
+            OR (m.receiverId = :targetUserId AND m.senderId =:userId AND m.deletedBySender = false)
+            ORDER BY m.createdAt DESC
+            """)
+    List<Message> findConversation(@Param("userId") Long userId, @Param("targetUserId") Long targetUserId);
+
 }

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -11,8 +11,8 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     // 삭제되지 않은 메시지 전부 최신순으로 반환
     @Query("""
             SELECT m FROM Message m
-            WHERE (m.receiverId = :userId OR m.senderId = :userId)
-            AND (m.deletedByReceiver = false OR m.deletedBySender = false)
+            WHERE (m.receiverId = :userId AND m.deletedByReceiver = false)
+            OR (m.senderId = :userId AND m.deletedBySender = false)
             ORDER BY m.createdAt DESC
             """)
     List<Message> findAllRelatedMessages(@Param("userId") Long userId);

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -27,7 +27,9 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             """)
     List<Message> findConversation(@Param("userId") Long userId, @Param("targetUserId") Long targetUserId);
 
-    List<Message> findByReceiverIdAndSenderIdAndDeletedByReceiver(Long userId, Long targetUserId, boolean deletedReceiver);
 
-    List<Message> findBySenderIdAndReceiverIdAndDeletedBySender(Long userId, Long targetUserId, boolean deletedSender);
+    List<Message> findBySenderIdAndReceiverIdAndDeletedBySenderFalse(Long senderId, Long receiverId);
+
+    List<Message> findByReceiverIdAndSenderIdAndDeletedByReceiverFalse(Long receiverId, Long senderId);
+
 }

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -27,4 +27,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             """)
     List<Message> findConversation(@Param("userId") Long userId, @Param("targetUserId") Long targetUserId);
 
+    List<Message> findByReceiverIdAndSenderIdAndDeletedByReceiver(Long userId, Long targetUserId, boolean deletedReceiver);
+
+    List<Message> findBySenderIdAndReceiverIdAndDeletedBySender(Long userId, Long targetUserId, boolean deletedSender);
 }

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -1,0 +1,29 @@
+package com.gucci.message_service.service;
+
+import com.gucci.message_service.domain.Message;
+import com.gucci.message_service.dto.MessageResponseDTO;
+import com.gucci.message_service.dto.MessageSendRequestDTO;
+import com.gucci.message_service.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+
+    // 메시지 전송
+    public void send(Long senderId, MessageSendRequestDTO request) {
+        Message message = Message.builder()
+                .senderId(senderId)
+                .receiverId(request.getReceiverId())
+                .content(request.getContent())
+                .build();
+
+        messageRepository.save(message);
+    }
+
+}

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -52,4 +52,22 @@ public class MessageService {
 
         return new ArrayList<>(rooms.values());
     }
+
+    public List<MessageResponseDTO> getMessagesWithTarget(Long userId, Long targetUserId) {
+        List<Message> messages = messageRepository.findConversation(userId, targetUserId);
+        return messages.stream()
+                .map(this::convertToDTO)
+                .toList();
+    }
+
+    private MessageResponseDTO convertToDTO(Message message) {
+        return MessageResponseDTO.builder()
+                .id(message.getId())
+                .receiverId(message.getReceiverId())
+                .senderId(message.getSenderId())
+                .content(message.getContent())
+                .isRead(message.isRead())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -2,12 +2,13 @@ package com.gucci.message_service.service;
 
 import com.gucci.message_service.domain.Message;
 import com.gucci.message_service.dto.MessageResponseDTO;
+import com.gucci.message_service.dto.MessageRoomResponseDTO;
 import com.gucci.message_service.dto.MessageSendRequestDTO;
 import com.gucci.message_service.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,4 +27,29 @@ public class MessageService {
         messageRepository.save(message);
     }
 
+    // 방 리스트 조회
+    public List<MessageRoomResponseDTO> getRooms(Long userId) {
+        // 로그인 한 유저의 삭제되지 않은 메시지 전체 조회
+        List<Message> allMessages = messageRepository.findAllRelatedMessages(userId);
+
+        Map<Long, MessageRoomResponseDTO> rooms = new LinkedHashMap<>();
+
+        for (Message message : allMessages) {
+            Long targetId = message.getSenderId().equals(userId)
+                    ? message.getReceiverId()
+                    : message.getSenderId();
+
+            // 이미 맵에 등록됐으면 스킵
+            if(rooms.containsKey(targetId)) continue;
+
+            rooms.put(targetId, MessageRoomResponseDTO.builder()
+                    .targetUserId(targetId)
+                    .targetNickname("닉네임") // JWT에서 닉네임 가져오기
+                    .lastMessage(message.getContent())
+                    .lastMessageTime(message.getCreatedAt())
+                    .build());
+        }
+
+        return new ArrayList<>(rooms.values());
+    }
 }

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -75,6 +75,37 @@ public class MessageService {
                 .build();
     }
 
+    // 특정 유저와의 대화 전체 삭제
+    @Transactional
+    public void exitRoomWithTarget(Long userId, Long targetUserId) {
+        // 보낸 메시지
+        List<Message> sentMessages = messageRepository.findByReceiverIdAndSenderIdAndDeletedByReceiverFalse(userId, targetUserId);
+
+        // 받은 메시지
+        List<Message> receivedMessages = messageRepository.findBySenderIdAndReceiverIdAndDeletedBySenderFalse(userId, targetUserId);
+
+        for (Message message : sentMessages) {
+            message.markAsDeleteBySender();
+        }
+
+        for (Message message : receivedMessages) {
+            message.markAsDeleteByReceiver();
+        }
+
+        // 두 사용자에게 삭제된 메시지 DB에서 삭제
+        List<Message> toDelete = new ArrayList<>();
+
+        toDelete.addAll(sentMessages.stream()
+                .filter(message -> message.isDeletedBySender() && message.isDeletedByReceiver())
+                .toList());
+
+
+        toDelete.addAll(receivedMessages.stream()
+                .filter(message -> message.isDeletedBySender() && message.isDeletedByReceiver())
+                .toList());
+
+        messageRepository.deleteAll(toDelete);
+    }
 
     @Transactional
     public void deleteMessage(Long userId, Long messageId) {


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-90](https://sh0314.atlassian.net/browse/GUC-90)
- 관련 GitHub 이슈: #1 
---

## ✨ PR Description

- 초기 디렉토리 구성을 완료했습니다.
- 메시지의 전송 / 조회 삭제를 구현했습니다.
 - 메시지의 삭제는 수신자, 발신자 모두 삭제를 해야 실제 DB에서 삭제됩니다.
 - 메시지의 조회는 채팅방 -> 특정 유저 선택 -> 특정 유저와의 전체 메시지 보기와 같은 흐름으로 구성했습니다.

---

## 📝 Requirements for Reviewer

---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [x] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [x] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-90]: https://sh0314.atlassian.net/browse/GUC-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ