### PR TITLE
메시지 읽음 처리 / 안 읽은 메시지 개수 반환

### DIFF
--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -36,7 +36,7 @@ public class MessageController {
     // 특정 유저와의 전체 메시지 조회
     @GetMapping("/with/{targetUserId}")
     public ApiResponse<List<MessageResponseDTO>> getMessagesWithTarget(@RequestHeader("X-User-Id") Long userId,
-                                                             @PathVariable Long targetUserId) {
+                                                                       @PathVariable Long targetUserId) {
         List<MessageResponseDTO> messages = messageService.getMessagesWithTarget(userId, targetUserId);
         return ApiResponse.success(SuccessCode.DATA_FETCHED, messages);
     }
@@ -57,5 +57,9 @@ public class MessageController {
         return ApiResponse.success();
     }
 
-
+    // 전체 안 읽은 메시지 수 조회
+    @GetMapping("/count/unread")
+    public ApiResponse<Long> getUnreadCount(@RequestHeader("X-User-Id") Long userId) {
+        return ApiResponse.success(messageService.getAllUnreadCount(userId));
+    }
 }

--- a/src/main/java/com/gucci/message_service/dto/MessageRoomResponseDTO.java
+++ b/src/main/java/com/gucci/message_service/dto/MessageRoomResponseDTO.java
@@ -14,4 +14,5 @@ public class MessageRoomResponseDTO {
     private String targetNickname; // 상대방 이름
     private String lastMessage;
     private LocalDateTime lastMessageTime;
+    private Long unreadCount;
 }

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -32,4 +32,7 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     List<Message> findByReceiverIdAndSenderIdAndDeletedByReceiverFalse(Long receiverId, Long senderId);
 
+
+    long countBySenderIdAndReceiverIdAndIsReadFalse(Long senderId, Long receiverId);
+
 }

--- a/src/main/java/com/gucci/message_service/repository/MessageRepository.java
+++ b/src/main/java/com/gucci/message_service/repository/MessageRepository.java
@@ -35,4 +35,5 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
 
     long countBySenderIdAndReceiverIdAndIsReadFalse(Long senderId, Long receiverId);
 
+    long countByReceiverIdAndIsReadFalseAndDeletedByReceiverFalse(Long userId);
 }

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -57,8 +57,17 @@ public class MessageService {
     }
 
     // 특정 유저(방)의 전체 메시지 조회
+    @Transactional
     public List<MessageResponseDTO> getMessagesWithTarget(Long userId, Long targetUserId) {
         List<Message> messages = messageRepository.findConversation(userId, targetUserId);
+
+        // 방 입장 시 전체 읽음 처리
+        for(Message message : messages){
+            if (message.getReceiverId().equals(userId) && !message.isRead()) {
+                message.markAsRead();
+            }
+        }
+
         return messages.stream()
                 .map(this::convertToDTO)
                 .toList();

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -45,11 +45,13 @@ public class MessageService {
             // 이미 맵에 등록됐으면 스킵
             if(rooms.containsKey(targetId)) continue;
 
+            long unreadCount = messageRepository.countBySenderIdAndReceiverIdAndIsReadFalse(targetId, userId);
             rooms.put(targetId, MessageRoomResponseDTO.builder()
                     .targetUserId(targetId)
                     .targetNickname("닉네임") // JWT에서 닉네임 가져오기
                     .lastMessage(message.getContent())
                     .lastMessageTime(message.getCreatedAt())
+                    .unreadCount(unreadCount)
                     .build());
         }
 

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -136,4 +136,8 @@ public class MessageService {
             messageRepository.delete(message);
         }
     }
+
+    public long getAllUnreadCount(Long userId) {
+        return messageRepository.countByReceiverIdAndIsReadFalseAndDeletedByReceiverFalse(userId);
+    }
 }


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-93](https://sh0314.atlassian.net/browse/GUC-93)
- 관련 GitHub 이슈: #3 

---

## ✨ PR Description

- 채팅방에 들어갔을 때 자동으로 읽음 처리 되도록 변경
- 각 채팅방 별, 전체 안 읽은 메시지 개수 반환 API 추가

---

## 📝 Requirements for Reviewer

---

## ✅ 체크리스트

- [x] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [x] 불필요한 주석, 디버깅 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-93]: https://sh0314.atlassian.net/browse/GUC-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ