### PR TITLE
JWT 응답 필터 구성 / FeignClient 설정 및 유저 서비스와 연동 확인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
+	id 'org.springframework.boot' version '3.2.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,13 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson serializer 사용
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.0"
+	}
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	implementation 'com.github.Gachon-Univ-Creative-Code-Innovation:alog-common:v1.0.2'
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 	implementation 'org.postgresql:postgresql:42.6.0'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // Jackson serializer 사용
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gucci/message_service/MessageServiceApplication.java
+++ b/src/main/java/com/gucci/message_service/MessageServiceApplication.java
@@ -2,8 +2,10 @@ package com.gucci.message_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class MessageServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/gucci/message_service/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtAuthenticationFilter.java
@@ -24,7 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtProvider.validateToken(token)) {
             Long userId = jwtProvider.getUserId(token);
             String nickname = jwtProvider.getNickname(token);
-            JwtUserAuthentication authentication = new JwtUserAuthentication(userId, nickname);
+            JwtUserAuthentication authentication = new JwtUserAuthentication(userId, nickname, token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/gucci/message_service/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,34 @@
+package com.gucci.message_service.auth;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtProvider.resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            JwtUserAuthentication authentication = new JwtUserAuthentication(userId);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+
+}

--- a/src/main/java/com/gucci/message_service/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtAuthenticationFilter.java
@@ -23,7 +23,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtProvider.validateToken(token)) {
             Long userId = jwtProvider.getUserId(token);
-            JwtUserAuthentication authentication = new JwtUserAuthentication(userId);
+            String nickname = jwtProvider.getNickname(token);
+            JwtUserAuthentication authentication = new JwtUserAuthentication(userId, nickname);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/gucci/message_service/auth/JwtProvider.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtProvider.java
@@ -1,0 +1,68 @@
+package com.gucci.message_service.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+
+    // secretKey를 Base64로 디코딩하여 Key 객체로 변환
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // JWT에서 사용자 ID 추출
+    public Long getUserId(String token) {
+        Long userId = parseClaims(token).get("user_id", Long.class);
+        log.info("User id: {}", userId);
+        return userId;
+    }
+
+    // 토큰의 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // 요청 헤더에서 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if(bearerToken != null && bearerToken.startsWith("Bearer ")){
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 내부적으로 Claims 파싱
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(this.key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/gucci/message_service/auth/JwtProvider.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtProvider.java
@@ -37,6 +37,13 @@ public class JwtProvider {
         return userId;
     }
 
+    // JWT에서 사용자 닉네임 추출
+    public String getNickname(String token) {
+        String nickname = parseClaims(token).get("nickname", String.class);
+        log.info("Nickname: {}", nickname);
+        return nickname;
+    }
+
     // 토큰의 유효성 검사
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/com/gucci/message_service/auth/JwtUserAuthentication.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtUserAuthentication.java
@@ -1,14 +1,18 @@
 package com.gucci.message_service.auth;
 
+import lombok.Getter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 
+@Getter
 public class JwtUserAuthentication extends AbstractAuthenticationToken {
 
     private final Long userId;
+    private final String nickname;
 
-    public JwtUserAuthentication(Long userId) {
+    public JwtUserAuthentication(Long userId, String nickname) {
         super(null);
         this.userId = userId;
+        this.nickname = nickname;
         setAuthenticated(true);
     }
 

--- a/src/main/java/com/gucci/message_service/auth/JwtUserAuthentication.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtUserAuthentication.java
@@ -8,11 +8,13 @@ public class JwtUserAuthentication extends AbstractAuthenticationToken {
 
     private final Long userId;
     private final String nickname;
+    private final String token;
 
-    public JwtUserAuthentication(Long userId, String nickname) {
+    public JwtUserAuthentication(Long userId, String nickname, String token) {
         super(null);
         this.userId = userId;
         this.nickname = nickname;
+        this.token = token;
         setAuthenticated(true);
     }
 

--- a/src/main/java/com/gucci/message_service/auth/JwtUserAuthentication.java
+++ b/src/main/java/com/gucci/message_service/auth/JwtUserAuthentication.java
@@ -1,0 +1,24 @@
+package com.gucci.message_service.auth;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtUserAuthentication extends AbstractAuthenticationToken {
+
+    private final Long userId;
+
+    public JwtUserAuthentication(Long userId) {
+        super(null);
+        this.userId = userId;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+}

--- a/src/main/java/com/gucci/message_service/auth/util/JwtUtil.java
+++ b/src/main/java/com/gucci/message_service/auth/util/JwtUtil.java
@@ -1,0 +1,27 @@
+package com.gucci.message_service.auth.util;
+
+import com.gucci.common.exception.CustomException;
+import com.gucci.common.exception.ErrorCode;
+import com.gucci.message_service.auth.JwtUserAuthentication;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class JwtUtil {
+
+    public static JwtUserAuthentication getCurrentUserAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof JwtUserAuthentication jwtAuth && jwtAuth.isAuthenticated()) {
+            return jwtAuth;
+        }
+        throw new CustomException(ErrorCode.FORBIDDEN);
+    }
+
+    public static Long getCurrentUserId() {
+        return getCurrentUserAuthentication().getUserId();
+    }
+
+    public static String getCurrentNickname() {
+        return getCurrentUserAuthentication().getNickname();
+    }
+}

--- a/src/main/java/com/gucci/message_service/client/UserClient.java
+++ b/src/main/java/com/gucci/message_service/client/UserClient.java
@@ -1,0 +1,17 @@
+package com.gucci.message_service.client;
+
+import com.gucci.common.response.ApiResponse;
+import com.gucci.message_service.config.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "user-service",
+        url = "http://localhost:8081/api/user-service",
+        configuration = FeignConfig.class) // 추후 포트 번호 변경 필요
+public interface UserClient {
+
+    @GetMapping("/{userId}/nickname")
+    ApiResponse<String> getNicknameById(@PathVariable Long userId);
+}

--- a/src/main/java/com/gucci/message_service/config/FeignConfig.java
+++ b/src/main/java/com/gucci/message_service/config/FeignConfig.java
@@ -1,0 +1,21 @@
+package com.gucci.message_service.config;
+
+import com.gucci.message_service.auth.JwtUserAuthentication;
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class FeignConfig implements RequestInterceptor {
+    @Override
+    public void apply(RequestTemplate template) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof JwtUserAuthentication jwtAuth) {
+            String token = jwtAuth.getToken();
+            template.header("Authorization", "Bearer " + token);
+        }
+    }
+}

--- a/src/main/java/com/gucci/message_service/config/SecurityConfig.java
+++ b/src/main/java/com/gucci/message_service/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.gucci.message_service.config;
+
+import com.gucci.message_service.auth.JwtAuthenticationFilter;
+import com.gucci.message_service.auth.JwtProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
+
+    public SecurityConfig(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -5,8 +5,10 @@ import com.gucci.common.response.SuccessCode;
 import com.gucci.message_service.dto.MessageResponseDTO;
 import com.gucci.message_service.dto.MessageRoomResponseDTO;
 import com.gucci.message_service.dto.MessageSendRequestDTO;
+import com.gucci.message_service.service.AuthServiceHelper;
 import com.gucci.message_service.service.MessageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,49 +19,58 @@ import java.util.List;
 public class MessageController {
 
     private final MessageService messageService;
+    private final AuthServiceHelper authServiceHelper;
 
     // 메시지 전송
     @PostMapping("/send")
-    public ApiResponse<Void> send(@RequestHeader("X-User-Id") Long senderId,
+    public ApiResponse<Void> send(Authentication authentication,
                                   @RequestBody MessageSendRequestDTO message) {
+        Long senderId = authServiceHelper.getCurrentUserId(authentication);
         messageService.send(senderId, message);
         return ApiResponse.success();
     }
 
     // 방 리스트 조회
     @GetMapping("/rooms")
-    public ApiResponse<List<MessageRoomResponseDTO>> getRooms(@RequestHeader("X-User-Id") Long userId) {
+    public ApiResponse<List<MessageRoomResponseDTO>> getRooms(Authentication authentication) {
+        Long userId = authServiceHelper.getCurrentUserId(authentication);
         List<MessageRoomResponseDTO> rooms = messageService.getRooms(userId);
         return ApiResponse.success(SuccessCode.DATA_FETCHED, rooms);
     }
 
     // 특정 유저와의 전체 메시지 조회
     @GetMapping("/with/{targetUserId}")
-    public ApiResponse<List<MessageResponseDTO>> getMessagesWithTarget(@RequestHeader("X-User-Id") Long userId,
+    public ApiResponse<List<MessageResponseDTO>> getMessagesWithTarget(Authentication authentication,
                                                                        @PathVariable Long targetUserId) {
+        Long userId = authServiceHelper.getCurrentUserId(authentication);
         List<MessageResponseDTO> messages = messageService.getMessagesWithTarget(userId, targetUserId);
         return ApiResponse.success(SuccessCode.DATA_FETCHED, messages);
     }
 
     // 특정 메시지 삭제
     @DeleteMapping("/{messageId}")
-    public ApiResponse<Void> deleteMessage(@RequestHeader("X-User-Id") Long userId,
+    public ApiResponse<Void> deleteMessage(Authentication authentication,
                                            @PathVariable Long messageId) {
+        Long userId = authServiceHelper.getCurrentUserId(authentication);
         messageService.deleteMessage(userId, messageId);
         return ApiResponse.success();
     }
 
     // 방 나가기 (특정 유저와의 메시지 전체 삭제(논리적))
     @PostMapping("/room/exit/{targetUserId}")
-    public ApiResponse<Void> exitRoomWithTarget(@RequestHeader("X-User-Id") Long userId,
+    public ApiResponse<Void> exitRoomWithTarget(Authentication authentication,
                                                 @PathVariable Long targetUserId) {
+        Long userId = authServiceHelper.getCurrentUserId(authentication);
         messageService.exitRoomWithTarget(userId, targetUserId);
         return ApiResponse.success();
     }
 
     // 전체 안 읽은 메시지 수 조회
     @GetMapping("/count/unread")
-    public ApiResponse<Long> getUnreadCount(@RequestHeader("X-User-Id") Long userId) {
+    public ApiResponse<Long> getUnreadCount(Authentication authentication) {
+        Long userId = authServiceHelper.getCurrentUserId(authentication);
         return ApiResponse.success(messageService.getAllUnreadCount(userId));
     }
 }
+
+

--- a/src/main/java/com/gucci/message_service/service/AuthServiceHelper.java
+++ b/src/main/java/com/gucci/message_service/service/AuthServiceHelper.java
@@ -1,0 +1,17 @@
+package com.gucci.message_service.service;
+
+import com.gucci.common.exception.CustomException;
+import com.gucci.common.exception.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthServiceHelper {
+    public Long getCurrentUserId(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return (Long) authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -2,6 +2,7 @@ package com.gucci.message_service.service;
 
 import com.gucci.common.exception.CustomException;
 import com.gucci.common.exception.ErrorCode;
+import com.gucci.message_service.client.UserClient;
 import com.gucci.message_service.domain.Message;
 import com.gucci.message_service.dto.MessageResponseDTO;
 import com.gucci.message_service.dto.MessageRoomResponseDTO;
@@ -18,6 +19,7 @@ import java.util.*;
 public class MessageService {
 
     private final MessageRepository messageRepository;
+    private final UserClient userClient;
 
     // 메시지 전송
     public void send(Long senderId, MessageSendRequestDTO request) {
@@ -48,7 +50,7 @@ public class MessageService {
             long unreadCount = messageRepository.countBySenderIdAndReceiverIdAndIsReadFalse(targetId, userId);
             rooms.put(targetId, MessageRoomResponseDTO.builder()
                     .targetUserId(targetId)
-                    .targetNickname("닉네임") // JWT에서 닉네임 가져오기
+                    .targetNickname(getTargetNickname(targetId))
                     .lastMessage(message.getContent())
                     .lastMessageTime(message.getCreatedAt())
                     .unreadCount(unreadCount)
@@ -139,5 +141,10 @@ public class MessageService {
 
     public long getAllUnreadCount(Long userId) {
         return messageRepository.countByReceiverIdAndIsReadFalseAndDeletedByReceiverFalse(userId);
+    }
+
+    // 닉네임 추출
+    private String getTargetNickname(Long targetUserId) {
+        return userClient.getNicknameById(targetUserId).getData();
     }
 }


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-98](https://sh0314.atlassian.net/browse/GUC-98)
- 관련 GitHub 이슈: #4 

---

## ✨ PR Description

- JWT 응답 필터를 구성하여 토큰에서 유저의 정보를 추출 할 수 있도록 구성했습니다.
- 기존의 헤더에 UserId를 직접 입력하는 로직을 삭제하고 Access Token을 입력하여 UserId를 획득하는 방식으로 리팩토링 했습니다.
- 로그인 한 사용자가 아닌 다른 사용자의 정보를 획득하는 것은 Token 방식으로 불가하여, user-service에 REST API 요청을 보내는 방식으로 구성하여 상대방의 닉네임을 응답 받도록 구성했습니다.
  - 각 서비스간 통신은 FeignClient를 사용하여 통신하도록 했습니다.

---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요
    - ex) 메서드 `handleLoginRedirect()` 명칭 괜찮은지 봐주세요
    - ex) 코드 로직 중 `line 45~56` 성능 개선 가능할지 궁금합니다

---

## ✅ 체크리스트

- [ ] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-98]: https://sh0314.atlassian.net/browse/GUC-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ