### PR TITLE
DB에서 삭제 시 S3 파일도 삭제

### DIFF
--- a/src/main/java/com/gucci/message_service/service/S3Service.java
+++ b/src/main/java/com/gucci/message_service/service/S3Service.java
@@ -4,6 +4,8 @@ import com.gucci.message_service.config.S3Config;
 import com.gucci.message_service.dto.PresignedUrlResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -25,6 +27,7 @@ public class S3Service {
 
     private final S3Presigner s3Presigner;
     private final S3Config s3Config;
+    private final S3Client s3Client;
 
     public PresignedUrlResponseDTO generatePresignedUploadUrl(String fileName) {
         String bucketName = s3Config.getBucketName();
@@ -66,5 +69,14 @@ public class S3Service {
         PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
 
         return presignedRequest.url().toString();
+    }
+
+    public void deleteFile(String objectKey) {
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(s3Config.getBucketName())
+                .key(objectKey)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
     }
 }


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-114](https://sh0314.atlassian.net/browse/GUC-114)
- 관련 GitHub 이슈: #13 
---

## ✨ PR Description

- 두 사용자에게 서로 메시지가 삭제되어 실제 DB에서 메시지가 삭제된다면 S3에 파일이 존재할 이유가 없습니다.
- 따라서 DB에서 삭제된 (파일)메시지는 S3에서도 삭제되도록 했습니다.

---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요
    - ex) 메서드 `handleLoginRedirect()` 명칭 괜찮은지 봐주세요
    - ex) 코드 로직 중 `line 45~56` 성능 개선 가능할지 궁금합니다

---

## ✅ 체크리스트

- [ ] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-114]: https://sh0314.atlassian.net/browse/GUC-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ