### PR TITLE
현재 채팅방에 접속 상태일 시 읽음 처리 / 전송 추가

### DIFF
--- a/src/main/java/com/gucci/message_service/controller/MessageController.java
+++ b/src/main/java/com/gucci/message_service/controller/MessageController.java
@@ -75,6 +75,15 @@ public class MessageController {
         Long userId = authServiceHelper.getCurrentUserId(authentication);
         return ApiResponse.success(messageService.getAllUnreadCount(userId));
     }
+
+    // 메시지 읽음 처리
+    @PatchMapping("{messageId}/read")
+    public ApiResponse<Void> readMessage(Authentication authentication,
+                                         @PathVariable Long messageId) {
+        Long userId = authServiceHelper.getCurrentUserId(authentication);
+        messageService.markAsRead(messageId, userId);
+        return ApiResponse.success();
+    }
 }
 
 

--- a/src/main/java/com/gucci/message_service/domain/Message.java
+++ b/src/main/java/com/gucci/message_service/domain/Message.java
@@ -50,6 +50,10 @@ public class Message {
         }
     }
 
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
     public void markAsDeleteByReceiver() {
         this.deletedByReceiver = true;
     }

--- a/src/main/java/com/gucci/message_service/dto/WebSocketMessageRequestDTO.java
+++ b/src/main/java/com/gucci/message_service/dto/WebSocketMessageRequestDTO.java
@@ -7,8 +7,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class WebSocketMessageRequestDTO {
-    private String type; // AUTH or MESSAGE
+    private String type; // AUTH or MESSAGE or ENTER or LEAVE
     private String token; // type이 AUTH일 때 사용
+    private Long messageId;
+    private Long roomId; // 채팅방 입장 시 사용
     private Long receiverId;
     private String content;
     private MessageType messageType;

--- a/src/main/java/com/gucci/message_service/dto/WebSocketReadEventDTO.java
+++ b/src/main/java/com/gucci/message_service/dto/WebSocketReadEventDTO.java
@@ -1,0 +1,16 @@
+package com.gucci.message_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Builder.Default;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class WebSocketReadEventDTO {
+    @Default
+    private String type = "READ";
+    private Long messageId;
+    private Long readerId;
+}

--- a/src/main/java/com/gucci/message_service/service/MessageService.java
+++ b/src/main/java/com/gucci/message_service/service/MessageService.java
@@ -167,4 +167,20 @@ public class MessageService {
                 .map(this::convertToDTO)
                 .toList();
     }
+
+    // 메시지 읽음 처리
+    @Transactional
+    public void markAsRead(Long messageId, Long userId) {
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        if (!message.getReceiverId().equals(userId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        if (!message.isRead()) {
+            message.markAsRead();
+            messageRepository.save(message);
+        }
+    }
 }

--- a/src/main/java/com/gucci/message_service/websocket/ChatWebSocketHandler.java
+++ b/src/main/java/com/gucci/message_service/websocket/ChatWebSocketHandler.java
@@ -5,6 +5,7 @@ import com.gucci.message_service.auth.JwtProvider;
 import com.gucci.message_service.domain.Message;
 import com.gucci.message_service.dto.WebSocketMessageRequestDTO;
 import com.gucci.message_service.dto.WebSocketMessageResponseDTO;
+import com.gucci.message_service.dto.WebSocketReadEventDTO;
 import com.gucci.message_service.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -27,8 +29,10 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     private final JwtProvider jwtProvider;
 
     private final Map<Long, WebSocketSession> userSessions = new ConcurrentHashMap<>();
+    private final Map<Long, Long> userInRoom = new ConcurrentHashMap<>();
 
     @Override
+
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         log.info("웹 소켓 연결 되었습니다. 세션 ID : {}", session.getId());
     }
@@ -37,33 +41,86 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         WebSocketMessageRequestDTO request = objectMapper.readValue(message.getPayload(), WebSocketMessageRequestDTO.class);
         if ("AUTH".equals(request.getType())) {
-            if (jwtProvider.validateToken(request.getToken())) {
-                Long userId = jwtProvider.getUserId(request.getToken());
-                String nickname = jwtProvider.getNickname(request.getToken());
-                session.getAttributes().put("userId", userId);
-                session.getAttributes().put("nickname", nickname);
-                userSessions.put(userId, session);
-                log.info("WebSocket 인증 성공 - UserId : {}, NickName : {}", userId, nickname);
-            } else {
-                session.close(CloseStatus.POLICY_VIOLATION);
-                log.warn("WebSocket 인증 실패 - 유효하지 않은 토큰입니다.");
-            }
-
+            handleAuth(session, request);
             return;
         }
 
-
-        Long senderId = getUserId(session);
-        if (senderId == null) {
+        Long userId = getUserId(session);
+        if (userId == null) {
             log.warn("인증되지 않은 사용자가 메시지를 보냈습니다.");
             return;
         }
 
+        switch (request.getType()) {
+            case "ENTER":
+                handleEnterRoom(userId,request.getRoomId());
+                break;
+            case "LEAVE":
+                handleLeaveRoom(userId);
+                break;
+            case "MESSAGE":
+                handleChatMessage(request, userId);
+                break;
+            case "READ":
+                handleReadMessage(request, userId);
+                break;
+            default:
+                log.warn("알 수 없는 메시지 타입입니다: {}", request.getType());
+        }
+
+    }
+
+
+    private void handleEnterRoom(Long userId, Long roomId) {
+        userInRoom.put(userId, roomId);
+        log.info("유저 {} 채팅방 {} 입장", userId, roomId);
+    }
+
+    private void handleLeaveRoom(Long userId) {
+        userInRoom.remove(userId);
+        log.info("유저 {} 채팅방 퇴장", userId);
+    }
+
+    private void handleReadMessage(WebSocketMessageRequestDTO request, Long userId) throws Exception {
+        Long messageId = request.getMessageId();
+        Message message = messageRepository.findById(messageId).orElse(null);
+
+        if (message == null || !message.getReceiverId().equals(userId)) {
+            log.warn("읽을 수 없는 메시지입니다. messageId: {}, receiverId: {}", messageId, userId);
+            return;
+        }
+
+        Long myRoomId = userInRoom.get(userId);
+
+        if (myRoomId == null || !myRoomId.equals(request.getRoomId())) {
+            log.info("내가 현재 채팅방에 없으므로 읽음 알림 전송 생략. userId = {}", userId);
+            return;
+        }
+
+        if (!message.isRead()) {
+            message.markAsRead();
+            messageRepository.save(message);
+            log.info("메시지 읽음 처리 완료. messageId = {}", messageId);
+        }
+
+        WebSocketSession senderSession = userSessions.get(message.getSenderId());
+        if (senderSession != null && senderSession.isOpen()) {
+            WebSocketReadEventDTO readEventDTO = WebSocketReadEventDTO.builder()
+                    .messageId(messageId)
+                    .readerId(userId)
+                    .build();
+
+            senderSession.sendMessage(new TextMessage(objectMapper.writeValueAsString(readEventDTO)));
+            log.info("읽음 알림 전송 완료. to userId: {}", message.getSenderId());
+        }
+    }
+
+    private void handleChatMessage(WebSocketMessageRequestDTO request, Long userId) throws IOException {
         WebSocketSession receiverSession = userSessions.get(request.getReceiverId());
 
         Message savedMessage = messageRepository.save(
                 Message.builder()
-                        .senderId(senderId)
+                        .senderId(userId)
                         .receiverId(request.getReceiverId())
                         .messageType(request.getMessageType())
                         .content(request.getContent())
@@ -71,7 +128,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         );
 
         // 이 채팅방 안 읽은 메시지 수
-        long unreadCount = messageRepository.countBySenderIdAndReceiverIdAndIsReadFalse(senderId, request.getReceiverId());
+        long unreadCount = messageRepository.countBySenderIdAndReceiverIdAndIsReadFalse(userId, request.getReceiverId());
 
         // 전체 채팅방 안 읽은 메시지 수
         long totalUnreadCount = messageRepository.countByReceiverIdAndIsReadFalse(request.getReceiverId());
@@ -95,6 +152,20 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         } else {
             log.warn("연결되지 않거나 없는 사용자에게 메시지를 보냈습니다.");
 
+        }
+    }
+
+    private void handleAuth(WebSocketSession session, WebSocketMessageRequestDTO request) throws IOException {
+        if (jwtProvider.validateToken(request.getToken())) {
+            Long userId = jwtProvider.getUserId(request.getToken());
+            String nickname = jwtProvider.getNickname(request.getToken());
+            session.getAttributes().put("userId", userId);
+            session.getAttributes().put("nickname", nickname);
+            userSessions.put(userId, session);
+            log.info("WebSocket 인증 성공 - UserId : {}, NickName : {}", userId, nickname);
+        } else {
+            session.close(CloseStatus.POLICY_VIOLATION);
+            log.warn("WebSocket 인증 실패 - 유효하지 않은 토큰입니다.");
         }
     }
 


### PR DESCRIPTION
## 📌 Jira Issue

- 관련 티켓: [GUC-156](https://sh0314.atlassian.net/browse/GUC-156)
- 관련 GitHub 이슈: #19 
---

## ✨ PR Description

- 기존 로직에서는 사용자가 현재 채팅 방에 있을 때 메시지를 받아도 읽음 처리가 되지 않았음
- 채팅방 접속 여부를 따로 관리하고, 채팅방에 접속 중 일 때 상대방에게 메시지가 오면 WebSocket으로 읽음 처리를 한 후 상대방에게 읽었다는 응답을 보내도록 구성
- 프론트에서는 이 응답을 받고 안 읽음 표시를 사라지게 구현 할 수 있음

---

## 📝 Requirements for Reviewer

- 리뷰어가 특별히 봐줬으면 하는 부분이 있다면 여기에 적어주세요
    - ex) 메서드 `handleLoginRedirect()` 명칭 괜찮은지 봐주세요
    - ex) 코드 로직 중 `line 45~56` 성능 개선 가능할지 궁금합니다

---

## ✅ 체크리스트

- [ ] Jira 티켓 번호를 커밋 메시지에 포함했는가?
- [ ] GitHub 이슈에 `resolves: #번호`를 추가했는가?
- [ ] 불필요한 주석, 디버깅 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작 확인했는가?

---

## 📸 스크린샷 (선택)

> UI 변경 사항이 있다면 여기에 첨부해주세요 (Drag & Drop 가능)

---

## 🔍 기타 참고사항

> 리뷰어에게 공유하고 싶은 추가 정보가 있다면 여기에 작성해주세요

[GUC-156]: https://sh0314.atlassian.net/browse/GUC-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ